### PR TITLE
toggle feature for input field, css organized

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -21,3 +21,8 @@ $("input[type ='text']").keypress(function(event) {
         $("ul").append("<li><span><i class='fas fa-trash-alt'></i></span> " + todoText + "</li")
     }
 });
+
+// Toggling Todo input
+$(".fa-plus").click(function() {
+    $("input[type ='text']").fadeToggle();
+});


### PR DESCRIPTION
This adds a toggle feature for showing and removing the input field for the 'Add New Todo' input.  In jQuery uses `fadeToggle()`  when clicking on the `fa-plus` font icon, to fade the input box in and out.

Also, this adjusts some of the CSS code to be more organized. It is organized by specificity.